### PR TITLE
Taking the first available tag

### DIFF
--- a/.atomist/handlers/event/Build.ts
+++ b/.atomist/handlers/event/Build.ts
@@ -100,7 +100,8 @@ class PRBuild implements HandleEvent<GraphNode, GraphNode> {
                     name: "CreateGithubRelease", 
                     parameters: { 
                         owner: build.on().owner(),
-                        repo: build.on().name()
+                        repo: build.on().name(),
+                        tag: build.hasBuild().isTagged()[0].ref()
                     }
                 }
             })


### PR DESCRIPTION
I'm not entirely sure this would be enough, also I'm taking the first available tag of a commit but that could be the wrong one. We probably need more relationships from a build to the tag it targets.